### PR TITLE
ci: fix github actions deprecations (docker/build-push-action)

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -36,7 +36,7 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: docker/ci-image/Dockerfile


### PR DESCRIPTION
docker/build-push-action v3 => v6

I have made a seperate PR, because this one need to be more tested